### PR TITLE
Add Privacy Policy and Terms of Service pages

### DIFF
--- a/apps/web/app/components/Footer.tsx
+++ b/apps/web/app/components/Footer.tsx
@@ -38,8 +38,8 @@ export function Footer({ footerRef }: { footerRef: RefObject<HTMLElement | null>
             <p className="text-xs font-semibold uppercase tracking-wider text-black/30 mb-3">Resources</p>
             <ul className="space-y-2 text-sm text-black/50">
               <li><a href="#" className="hover:text-black transition-colors">About</a></li>
-              <li><a href="#" className="hover:text-black transition-colors">Privacy Policy</a></li>
-              <li><a href="#" className="hover:text-black transition-colors">Terms of Service</a></li>
+              <li><a href="/privacy-policy" className="hover:text-black transition-colors">Privacy Policy</a></li>
+              <li><a href="/terms-of-service" className="hover:text-black transition-colors">Terms of Service</a></li>
               <li><a href="#" className="hover:text-black transition-colors">Contact</a></li>
             </ul>
           </div>

--- a/apps/web/app/privacy-policy/page.tsx
+++ b/apps/web/app/privacy-policy/page.tsx
@@ -1,0 +1,212 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Tracky",
+  description:
+    "Tracky's privacy policy. Learn how we handle your data when you use the Tracky app and website.",
+};
+
+export default function PrivacyPolicy() {
+  return (
+    <main className="min-h-screen bg-white px-6 py-20">
+      <div className="max-w-3xl mx-auto">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-black/40 hover:text-black transition-colors mb-12"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+          Back to home
+        </Link>
+
+        <h1 className="text-4xl font-bold tracking-tight mb-2">
+          Privacy Policy
+        </h1>
+        <p className="text-black/40 text-sm mb-12">
+          Last updated: March 16, 2026
+        </p>
+
+        <div className="space-y-10 text-[15px] leading-relaxed text-black/70">
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Overview
+            </h2>
+            <p>
+              Tracky is a real-time Amtrak tracking app for iOS and Android.
+              We believe your privacy matters, and we&apos;ve designed Tracky to
+              collect as little data as possible while still providing a great
+              experience. This policy explains what we collect, why, and how
+              we handle it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Information We Collect
+            </h2>
+
+            <h3 className="font-medium text-black mt-4 mb-2">
+              Information you provide
+            </h3>
+            <ul className="list-disc pl-5 space-y-1.5">
+              <li>
+                Saved trips and route preferences you choose to store within
+                the app.
+              </li>
+              <li>
+                Any feedback or messages you send us via email.
+              </li>
+            </ul>
+
+            <h3 className="font-medium text-black mt-4 mb-2">
+              Information collected automatically
+            </h3>
+            <ul className="list-disc pl-5 space-y-1.5">
+              <li>
+                <strong>Device information:</strong> Device type, operating
+                system version, and app version for compatibility and
+                debugging purposes.
+              </li>
+              <li>
+                <strong>Usage data:</strong> General app usage patterns such
+                as feature interactions, session duration, and crash reports
+                to help us improve the app.
+              </li>
+              <li>
+                <strong>Website analytics:</strong> We use{" "}
+                <a
+                  href="https://www.rybbit.io"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-black transition-colors"
+                >
+                  Rybbit
+                </a>
+                , a privacy-focused analytics tool, on our website to
+                understand page views and general traffic patterns. No
+                personal data or cookies are used for this purpose.
+              </li>
+            </ul>
+
+            <h3 className="font-medium text-black mt-4 mb-2">
+              Information we do not collect
+            </h3>
+            <ul className="list-disc pl-5 space-y-1.5">
+              <li>We do not track your physical location.</li>
+              <li>We do not require you to create an account.</li>
+              <li>
+                We do not sell, share, or monetize your personal data in any
+                way.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              How We Use Your Information
+            </h2>
+            <p>The limited information we collect is used to:</p>
+            <ul className="list-disc pl-5 space-y-1.5 mt-2">
+              <li>Provide and maintain Tracky&apos;s features.</li>
+              <li>
+                Send you notifications about train status updates, delays,
+                and departures (only if you opt in).
+              </li>
+              <li>Fix bugs, improve performance, and develop new features.</li>
+              <li>Respond to your feedback and support requests.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Data Storage &amp; Security
+            </h2>
+            <p>
+              Your saved trips and preferences are stored locally on your
+              device. We use industry-standard security measures to protect
+              any data transmitted to our servers. No payment information is
+              collected or processed by Tracky directly.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Third-Party Services
+            </h2>
+            <p>
+              Tracky relies on third-party services to provide train data and
+              app functionality. These services may collect data independently
+              according to their own privacy policies:
+            </p>
+            <ul className="list-disc pl-5 space-y-1.5 mt-2">
+              <li>
+                <strong>Amtrak</strong> &mdash; for real-time train data,
+                schedules, and status information.
+              </li>
+              <li>
+                <strong>Apple App Store / Google Play Store</strong> &mdash;
+                for app distribution and updates.
+              </li>
+              <li>
+                <strong>Rybbit</strong> &mdash; for privacy-focused website
+                analytics.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Children&apos;s Privacy
+            </h2>
+            <p>
+              Tracky does not knowingly collect personal information from
+              children under 13. If you believe a child has provided us with
+              personal data, please contact us so we can take appropriate
+              action.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Changes to This Policy
+            </h2>
+            <p>
+              We may update this privacy policy from time to time. Changes
+              will be posted on this page with a revised &ldquo;last
+              updated&rdquo; date. Continued use of Tracky after changes
+              constitutes acceptance of the updated policy.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Contact Us
+            </h2>
+            <p>
+              If you have questions about this privacy policy or how Tracky
+              handles your data, reach out to us at{" "}
+              <a
+                href="mailto:him@jasonxu.me?subject=Tracky Privacy"
+                className="underline hover:text-black transition-colors"
+              >
+                him@jasonxu.me
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/terms-of-service/page.tsx
+++ b/apps/web/app/terms-of-service/page.tsx
@@ -1,0 +1,232 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — Tracky",
+  description:
+    "Tracky's terms of service. Read the terms and conditions for using the Tracky app and website.",
+};
+
+export default function TermsOfService() {
+  return (
+    <main className="min-h-screen bg-white px-6 py-20">
+      <div className="max-w-3xl mx-auto">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-black/40 hover:text-black transition-colors mb-12"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+          Back to home
+        </Link>
+
+        <h1 className="text-4xl font-bold tracking-tight mb-2">
+          Terms of Service
+        </h1>
+        <p className="text-black/40 text-sm mb-12">
+          Last updated: March 16, 2026
+        </p>
+
+        <div className="space-y-10 text-[15px] leading-relaxed text-black/70">
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Agreement to Terms
+            </h2>
+            <p>
+              By downloading, installing, or using Tracky (&ldquo;the
+              App&rdquo;) or visiting our website (&ldquo;the Site&rdquo;),
+              you agree to be bound by these Terms of Service. If you do not
+              agree to these terms, please do not use Tracky.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Description of Service
+            </h2>
+            <p>
+              Tracky is a free, open-source application that provides
+              real-time Amtrak train tracking, departure boards, live maps,
+              delay notifications, and related transit information. The App is
+              available on iOS and Android.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Use of the Service
+            </h2>
+            <p>You agree to use Tracky only for lawful purposes. You may not:</p>
+            <ul className="list-disc pl-5 space-y-1.5 mt-2">
+              <li>
+                Use the App in any way that violates applicable laws or
+                regulations.
+              </li>
+              <li>
+                Attempt to reverse-engineer, decompile, or extract source
+                code from the App beyond what is permitted by the open-source
+                license.
+              </li>
+              <li>
+                Use the App to interfere with or disrupt any servers,
+                networks, or services.
+              </li>
+              <li>
+                Scrape, collect, or harvest data from the App or its
+                underlying services in an automated manner for commercial
+                purposes.
+              </li>
+              <li>
+                Misrepresent your identity or affiliation when using the App
+                or contacting us.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Open-Source License
+            </h2>
+            <p>
+              Tracky is released under an open-source license. The source
+              code is available on{" "}
+              <a
+                href="https://github.com/Mootbing/Tracky"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-black transition-colors"
+              >
+                GitHub
+              </a>
+              . Your use of the source code is governed by the applicable
+              open-source license in the repository. These Terms of Service
+              govern your use of the App and Site as an end user.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Accuracy of Information
+            </h2>
+            <p>
+              Tracky displays train data sourced from Amtrak and other
+              third-party providers. While we strive to provide accurate and
+              up-to-date information, we cannot guarantee the accuracy,
+              completeness, or timeliness of any data displayed in the App.
+              Train schedules, delays, and status information may change
+              without notice.
+            </p>
+            <p className="mt-3">
+              <strong>
+                Tracky should not be your sole source of travel information.
+              </strong>{" "}
+              Always verify critical travel details directly with Amtrak or
+              your rail operator.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Notifications
+            </h2>
+            <p>
+              Tracky may send push notifications about train status, delays,
+              and departures if you opt in. We do our best to deliver
+              notifications promptly, but we do not guarantee the delivery,
+              timing, or accuracy of any notification. You can disable
+              notifications at any time through your device settings.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Intellectual Property
+            </h2>
+            <p>
+              The Tracky name, logo, and branding are the property of Tracky
+              and its contributors. Third-party trademarks, including Amtrak,
+              Apple, and Google, are the property of their respective owners
+              and are used for identification purposes only.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Disclaimer of Warranties
+            </h2>
+            <p>
+              Tracky is provided on an &ldquo;as is&rdquo; and &ldquo;as
+              available&rdquo; basis without warranties of any kind, whether
+              express or implied. We do not warrant that the App will be
+              uninterrupted, error-free, or free of harmful components. You
+              use Tracky at your own risk.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Limitation of Liability
+            </h2>
+            <p>
+              To the fullest extent permitted by law, Tracky and its
+              contributors shall not be liable for any indirect, incidental,
+              special, consequential, or punitive damages arising from your
+              use of or inability to use the App, including but not limited
+              to missed trains, incorrect schedule information, or reliance
+              on notifications.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Termination
+            </h2>
+            <p>
+              We reserve the right to restrict or terminate access to the App
+              or Site at any time, for any reason, without notice. You may
+              stop using Tracky at any time by uninstalling the App.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Changes to These Terms
+            </h2>
+            <p>
+              We may update these Terms of Service from time to time. Changes
+              will be posted on this page with a revised &ldquo;last
+              updated&rdquo; date. Continued use of Tracky after changes
+              constitutes acceptance of the updated terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-black mb-3">
+              Contact Us
+            </h2>
+            <p>
+              If you have questions about these terms, reach out to us at{" "}
+              <a
+                href="mailto:him@jasonxu.me?subject=Tracky Terms"
+                className="underline hover:text-black transition-colors"
+              >
+                him@jasonxu.me
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/privacy-policy` page covering data collection, storage, third-party services, and contact info
- Add `/terms-of-service` page covering usage terms, disclaimers, liability, and open-source license
- Update footer links to point to the new pages instead of `#` placeholders

## Test plan
- [ ] Visit `/privacy-policy` and verify content renders correctly
- [ ] Visit `/terms-of-service` and verify content renders correctly
- [ ] Click Privacy Policy and Terms of Service links in the footer
- [ ] Verify pages look correct on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)