### PR TITLE
Refactor top bubble: extract LoadingBubble + streaming suspense

### DIFF
--- a/apps/mobile/components/ui/LoadingBubble.tsx
+++ b/apps/mobile/components/ui/LoadingBubble.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { type ColorPalette, withTextShadow } from '../../constants/theme';
+import { useColors } from '../../context/ThemeContext';
+import AnimatedRollingText from './AnimatedRollingText';
+import { NoticeBubble } from './NoticeBubble';
+
+const createStyles = (colors: ColorPalette) =>
+  StyleSheet.create(withTextShadow({
+    pctText: {
+      fontSize: 12,
+      color: colors.primary,
+      fontWeight: '700',
+      minWidth: 32,
+      textAlign: 'right',
+    },
+    retryText: {
+      fontSize: 11,
+      color: 'rgba(255, 69, 58, 0.9)',
+      fontWeight: '600',
+    },
+  }, colors.textShadow));
+
+interface LoadingBubbleProps {
+  visible: boolean;
+  text: string;
+  /** 0–1 progress. Omit for indeterminate. */
+  progress?: number;
+  /** Show error state with retry interaction */
+  error?: boolean;
+  errorLabel?: string;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+}
+
+export function LoadingBubble({
+  visible,
+  text,
+  progress,
+  error,
+  errorLabel = 'Tap to retry',
+  onRetry,
+  onDismiss,
+}: LoadingBubbleProps) {
+  const colors = useColors();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const progressPct = progress != null ? Math.round(progress * 100) : null;
+  const isDone = progress != null && progress >= 1;
+
+  const trailing = error ? (
+    <Text style={styles.retryText}>{errorLabel}</Text>
+  ) : progressPct != null ? (
+    <AnimatedRollingText value={`${progressPct}%`} style={styles.pctText} />
+  ) : undefined;
+
+  return (
+    <NoticeBubble
+      visible={visible}
+      spinner={!error && !isDone}
+      icon={error ? '✕' : '✓'}
+      text={text}
+      progress={error ? undefined : progress}
+      error={error}
+      interactive={error}
+      onPress={onRetry}
+      onLongPress={onDismiss}
+      trailing={trailing}
+    />
+  );
+}

--- a/apps/mobile/components/ui/RefreshBubble.tsx
+++ b/apps/mobile/components/ui/RefreshBubble.tsx
@@ -1,45 +1,20 @@
-import React, { useMemo } from 'react';
-import { StyleSheet, Text } from 'react-native';
-import { type ColorPalette, withTextShadow } from '../../constants/theme';
-import { useColors } from '../../context/ThemeContext';
+import React from 'react';
 import { useGTFSRefresh } from '../../context/GTFSRefreshContext';
 import { light as hapticLight, warning as hapticWarning } from '../../utils/haptics';
-import AnimatedRollingText from './AnimatedRollingText';
-import { NoticeBubble } from './NoticeBubble';
-
-const createStyles = (colors: ColorPalette) =>
-  StyleSheet.create(withTextShadow({
-    pctText: {
-      fontSize: 12,
-      color: colors.primary,
-      fontWeight: '700',
-      minWidth: 32,
-      textAlign: 'right',
-    },
-    retryText: {
-      fontSize: 11,
-      color: 'rgba(255, 69, 58, 0.9)',
-      fontWeight: '600',
-    },
-  }, colors.textShadow));
+import { LoadingBubble } from './LoadingBubble';
 
 export function RefreshBubble() {
-  const colors = useColors();
-  const styles = useMemo(() => createStyles(colors), [colors]);
   const { isRefreshing, isStreamingData, refreshProgress, refreshStep, refreshFailed, triggerRefresh, dismissRefreshFailure } =
     useGTFSRefresh();
 
-  const progressPct = Math.round(refreshProgress * 100);
-  const isDone = refreshProgress >= 1;
-
-  const handlePress = () => {
+  const handleRetry = () => {
     if (refreshFailed) {
       hapticLight();
       triggerRefresh();
     }
   };
 
-  const handleLongPress = () => {
+  const handleDismiss = () => {
     if (refreshFailed) {
       hapticWarning();
       dismissRefreshFailure();
@@ -49,9 +24,8 @@ export function RefreshBubble() {
   // Streaming data bubble (shapes loading after splash)
   if (isStreamingData && !isRefreshing) {
     return (
-      <NoticeBubble
+      <LoadingBubble
         visible
-        spinner
         text="Streaming stations & routes"
       />
     );
@@ -59,23 +33,13 @@ export function RefreshBubble() {
 
   // Refresh / failure bubble
   return (
-    <NoticeBubble
+    <LoadingBubble
       visible={isRefreshing || refreshFailed}
-      spinner={!refreshFailed && !isDone}
-      icon={refreshFailed ? '✕' : '✓'}
       text={refreshFailed ? (refreshStep || 'Schedule update failed') : refreshStep || 'Updating schedule...'}
       progress={refreshFailed ? undefined : refreshProgress}
       error={refreshFailed}
-      interactive={refreshFailed}
-      onPress={handlePress}
-      onLongPress={handleLongPress}
-      trailing={
-        refreshFailed ? (
-          <Text style={styles.retryText}>Tap to retry</Text>
-        ) : (
-          <AnimatedRollingText value={`${progressPct}%`} style={styles.pctText} />
-        )
-      }
+      onRetry={handleRetry}
+      onDismiss={handleDismiss}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Extract reusable `LoadingBubble` component from `RefreshBubble`, separating presentation (progress %, retry text, spinner) from GTFS refresh logic
- `RefreshBubble` now cleanly handles streaming data suspense state (stations & routes loading after splash) as a distinct UI path
- Reduces `RefreshBubble` from inline styles + direct NoticeBubble wiring to a thin orchestrator

## Test plan
- [ ] Verify GTFS refresh bubble shows progress percentage during update
- [ ] Verify "Streaming stations & routes" bubble appears during initial data load
- [ ] Verify failed refresh shows retry/dismiss interactions
- [ ] Verify long-press dismisses failure state

🤖 Generated with [Claude Code](https://claude.com/claude-code)